### PR TITLE
Revert "Resolve the problem of using an external file to start up the FileNotFoundException"

### DIFF
--- a/src/main/java/com/github/hiwepy/ip2region/spring/boot/IP2regionAutoConfiguration.java
+++ b/src/main/java/com/github/hiwepy/ip2region/spring/boot/IP2regionAutoConfiguration.java
@@ -41,7 +41,7 @@ public class IP2regionAutoConfiguration implements ResourceLoaderAware {
 			
 			DBReader reader = null;
 			// 查找resource
-			Resource resource = resourceLoader.getResource("file:/" + properties.getLocation());
+			Resource resource = resourceLoader.getResource(properties.getLocation());
 			
 			if(resource.isFile() && resource.exists()) {
 				


### PR DESCRIPTION
Reverts hiwepy/ip2region-spring-boot-starter#5

你可以使用如下配置：

ip2region:
  external: true
  index-block-size: 4096
  total-header-size: 8192
  location:  file:/D:\SimpleCode\java-all-in-one\ip-location\ip2region\data\ip2region.db


在实际的项目中，可能会把外部库放在自己的项目下：

ip2region:
  external: true
  index-block-size: 4096
  total-header-size: 8192
  location:  classpath:ip2region.db

如果按你程序中写死的话，会导致只能使用文件路径方式！